### PR TITLE
Minor fix: Missing fi in resources-destroy target in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ resources-destroy: ## Remove sample application(s) from cluster (optionally spec
 			fi \
 		done; \
 		echo "All applications destroyed successfully!"; \
+	fi
 
 resources-validate: ## Validate sample application(s) in cluster (optionally specify app names)
 	@if [ "$(filter-out $@,$(MAKECMDGOALS))" ]; then \

--- a/sample-resources/hello-world/validate.sh
+++ b/sample-resources/hello-world/validate.sh
@@ -64,7 +64,7 @@ HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" --max-time "$TIMEOUT" "$URL" 2>&1)
 HTTP_STATUS=$(echo "$HTTP_RESPONSE" | tail -n 1)
 
 # Extract response body (everything except last line)
-RESPONSE_BODY=$(echo "$HTTP_RESPONSE" | head -n -1)
+RESPONSE_BODY=$(echo "$HTTP_RESPONSE" | sed '$d')
 
 echo "HTTP Status: $HTTP_STATUS"
 

--- a/sample-resources/wordpress/validate.sh
+++ b/sample-resources/wordpress/validate.sh
@@ -93,7 +93,7 @@ HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" --max-time "$TIMEOUT" "$URL" 2>&1)
 HTTP_STATUS=$(echo "$HTTP_RESPONSE" | tail -n 1)
 
 # Extract response body (everything except last line)
-RESPONSE_BODY=$(echo "$HTTP_RESPONSE" | head -n -1)
+RESPONSE_BODY=$(echo "$HTTP_RESPONSE" | sed '$d')
 
 echo "HTTP Status: $HTTP_STATUS"
 


### PR DESCRIPTION
Fixes an issue with head -n -1 which works fine on linux but due to implementation differences , on mac while validating it fails with an error - 
```
Handling connection for 18080
head: illegal line count -- -1
./validate.sh: line 96: echo: write error: Broken pipe
```
So using '$d' so that it works consistently on both mac and linux alike. 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conditional block termination in build scripts to ensure resource management and validation steps run reliably.
  * Improved HTTP response parsing in validation scripts to more robustly separate response body and status, reducing spurious validation failures in edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->